### PR TITLE
Bump embeddable to v0.14.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ x-logging: &default-logging
     max-file: "3"
 services:
   editor:
-    image: lblod/frontend-embeddable-editor:0.12.1
+    image: lblod/frontend-embeddable-editor:0.14.0
     links:
       - identifier:backend
     restart: always


### PR DESCRIPTION
https://github.com/lblod/frontend-embeddable-notule-editor/releases/tag/v0.14.0