### PR TITLE
bump embeddable to 0.16.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ x-logging: &default-logging
     max-file: "3"
 services:
   editor:
-    image: lblod/frontend-embeddable-editor:0.15.0
+    image: lblod/frontend-embeddable-editor:0.16.0
     links:
       - identifier:backend
     restart: always


### PR DESCRIPTION
https://github.com/lblod/frontend-embeddable-notule-editor/releases/tag/v0.16.0
# :rocket: Enhancement

 -    [#13](https://github.com/lblod/frontend-embeddable-notule-editor/pull/13) Adding roadsign regulation related plugins ([@benjay10](https://github.com/benjay10))
 -   [#10](https://github.com/lblod/frontend-embeddable-notule-editor/pull/10) Upgrade ember 3.28 ([@benjay10](https://github.com/benjay10))
 -   Upgraded ember-rdfa-editor to [0.56.2](https://github.com/lblod/ember-rdfa-editor/releases/tag/v0.56.2)

# :bug: Bug Fix

  -    [#12](https://github.com/lblod/frontend-embeddable-notule-editor/pull/12) Fix ember-concurrency dependency ([@benjay10](https://github.com/benjay10))

# :house: Internal

   - [#10](https://github.com/lblod/frontend-embeddable-notule-editor/pull/10) Upgrade ember 3.28 ([@benjay10](https://github.com/benjay10))
  -  [#11](https://github.com/lblod/frontend-embeddable-notule-editor/pull/11) Fix Drone setup ([@benjay10](https://github.com/benjay10))

# Committers: 1
    Ben ([@benjay10](https://github.com/benjay10))