### PR TITLE
move frontend behind dispatcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ x-logging: &default-logging
     max-size: "10m"
     max-file: "3"
 services:
-  editor:
+  identifier:
     environment:
       VIRTUAL_HOST: "editor.awesomecorp.com"
       LETSENCRYPT_HOST: "editor.awesomecorp.com"

--- a/config/delta/rules.js
+++ b/config/delta/rules.js
@@ -1,0 +1,14 @@
+export default [
+    {
+        match: {},
+        callback: {
+            url: "http://resource/.mu/delta",
+            method: "POST"
+        },
+        options: {
+            resourceFormat: "v0.0.1",
+            gracePeriod: 250,
+            ignoreFromSelf: true
+        }
+    }
+];

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -1,96 +1,147 @@
 defmodule Dispatcher do
   use Matcher
-  define_accept_types []
+  define_accept_types [
+    json: [ "application/json", "application/vnd.api+json" ],
+    html: [ "text/html", "application/xhtml+html" ],
+    sparql: [ "application/sparql-results+json" ],
+    any: [ "*/*" ]
+  ]
 
-  match "/codex/sparql/*path" do
+  define_layers [ :static, :frontend, :api_services, :not_found ]
+
+  options "/*_path", _ do
+    conn
+    |> Plug.Conn.put_resp_header( "access-control-allow-headers", "content-type,accept" )
+    |> Plug.Conn.put_resp_header( "access-control-allow-methods", "*" )
+    |> send_resp( 200, "{ \"message\": \"ok\" }" )
+  end
+
+  ###############
+  # STATIC
+  ###############
+  match "/", %{ layer: :static } do
+    forward conn, [], "http://editor/test.html"
+  end
+
+  match "/index.html", %{ layer: :static } do
+    forward conn, [], "http://editor/test.html"
+  end
+
+  match "/test.html", %{ layer: :static } do
+    forward conn, [], "http://editor/test.html"
+  end
+
+  get "/assets/*path",  %{ layer: :static } do
+    forward conn, path, "http://editor/assets/"
+  end
+
+  get "/@appuniversum/*path",  %{ layer: :static } do
+    forward conn, path, "http://editor/@appuniversum/"
+  end
+
+  get "/favicon.ico", %{ layer: :static }  do
+    send_resp( conn, 404, "" )
+  end
+
+  ###############
+  # API SERVICES
+  ###############
+
+
+  match "/codex/sparql/*path", %{ layer: :api_services, accept: %{ json: true } } do
     forward conn, path, "http://codex-proxy/sparql/"
   end
 
-  match "/concepts/*path" do
+  match "/concepts/*path", %{ layer: :api_services, accept: %{ json: true } } do
     forward conn, path, "http://cache/concepts/"
   end
 
-  match "/concept-schemes/*path" do
+  match "/concept-schemes/*path", %{ layer: :api_services, accept: %{ json: true } } do
     forward conn, path, "http://cache/concept-schemes/"
   end
 
-  match "/bestuurseenheden/*path" do
+  match "/bestuurseenheden/*path", %{ layer: :api_services, accept: %{ json: true } } do
     forward conn, path, "http://cache/bestuurseenheden/"
   end
 
-  match "/bestuurseenheid-classificatie-codes/*path" do
+  match "/bestuurseenheid-classificatie-codes/*path", %{ layer: :api_services, accept: %{ json: true } } do
     forward conn, path, "http://cache/bestuurseenheid-classificatie-codes/"
   end
 
-  match "/bestuursorganen/*path" do
+  match "/bestuursorganen/*path", %{ layer: :api_services, accept: %{ json: true } } do
     forward conn, path, "http://cache/bestuursorganen/"
   end
 
-  match "/bestuursorgaan-classificatie-codes/*path" do
+  match "/bestuursorgaan-classificatie-codes/*path", %{ layer: :api_services, accept: %{ json: true } } do
     forward conn, path, "http://cache/bestuursorgaan-classificatie-codes/"
   end
 
-  match "/fracties/*path" do
+  match "/fracties/*path", %{ layer: :api_services, accept: %{ json: true } } do
     forward conn, path, "http://resource/fracties/"
   end
 
-  match "/fractietypes/*path" do
+  match "/fractietypes/*path", %{ layer: :api_services, accept: %{ json: true } } do
     forward conn, path, "http://cache/fractietypes/"
   end
 
-  match "/mandaten/*path" do
+  match "/mandaten/*path", %{ layer: :api_services, accept: %{ json: true } } do
     forward conn, path, "http://resource/mandaten/"
   end
 
-  match "/bestuursfunctie-codes/*path" do
+  match "/bestuursfunctie-codes/*path", %{ layer: :api_services, accept: %{ json: true } } do
     forward conn, path, "http://cache/bestuursfunctie-codes/"
   end
 
-  match "/mandatarissen/*path" do
+  match "/mandatarissen/*path", %{ layer: :api_services, accept: %{ json: true } } do
     forward conn, path, "http://cache/mandatarissen/"
   end
 
-  match "/mandataris-status-codes/*path" do
+  match "/mandataris-status-codes/*path", %{ layer: :api_services, accept: %{ json: true } } do
     forward conn, path, "http://cache/mandataris-status-codes/"
   end
 
-  match "/personen/*path" do
+  match "/personen/*path", %{ layer: :api_services, accept: %{ json: true } } do
     forward conn, path, "http://cache/personen/"
   end
 
-  match "/templates/*path" do
+  match "/templates/*path", %{ layer: :api_services, accept: %{ json: true } } do
     forward conn, path, "http://cache/templates/"
   end
 
-  match "/rdfs-classes/*path" do
+  match "/rdfs-classes/*path", %{ layer: :api_services, accept: %{ json: true } } do
     forward conn, path, "http://cache/rdfs-classes/"
   end
 
-  match "/rdfs-properties/*path" do
+  match "/rdfs-properties/*path", %{ layer: :api_services, accept: %{ json: true } } do
     forward conn, path, "http://cache/rdfs-properties/"
   end
 
-  match "/bestuursfuncties/*path" do
+  match "/bestuursfuncties/*path", %{ layer: :api_services, accept: %{ json: true } } do
     forward conn, path, "http://cache/bestuursfuncties/"
   end
 
-  match "/functionarissen/*path" do
+  match "/functionarissen/*path", %{ layer: :api_services, accept: %{ json: true } } do
     forward conn, path, "http://cache/functionarissen/"
   end
 
-  match "/contact-punten/*path" do
+  match "/contact-punten/*path", %{ layer: :api_services, accept: %{ json: true } } do
     forward conn, path, "http://cache/contact-punten/"
   end
 
-  match "/adressen/*path" do
+  match "/adressen/*path", %{ layer: :api_services, accept: %{ json: true } } do
     forward conn, path, "http://cache/adressen/"
   end
 
-  match "/functionaris-status-codes/*path" do
+  match "/functionaris-status-codes/*path", %{ layer: :api_services, accept: %{ json: true } } do
     forward conn, path, "http://cache/functionaris-status-codes/"
   end
 
-  match "/_", %{ last_call: true } do
+  #################
+  # NOT FOUND
+  #################
+
+  match "/*_path", %{ layer: :not_found } do
     send_resp( conn, 404, "Route not found.  See config/dispatcher.ex" )
   end
+
 end

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -48,7 +48,7 @@ defmodule Dispatcher do
   ###############
 
 
-  match "/codex/sparql/*path", %{ layer: :api_services, accept: %{ json: true } } do
+  match "/codex/sparql/*path", %{ layer: :api_services, accept: %{ sparql: true } } do
     forward conn, path, "http://codex-proxy/sparql/"
   end
 

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -19,6 +19,9 @@ defmodule Dispatcher do
   ###############
   # STATIC
   ###############
+  match "", %{ layer: :static } do
+    forward conn, [], "http://editor/test.html"
+  end
   match "/", %{ layer: :static } do
     forward conn, [], "http://editor/test.html"
   end
@@ -42,7 +45,6 @@ defmodule Dispatcher do
   get "/favicon.ico", %{ layer: :static }  do
     send_resp( conn, 404, "" )
   end
-
   ###############
   # API SERVICES
   ###############

--- a/docker-compose.http.yml
+++ b/docker-compose.http.yml
@@ -5,6 +5,6 @@ x-logging: &default-logging
     max-size: "10m"
     max-file: "3"
 services:
-  editor:
+  identifier:
     ports:
       - 80:80


### PR DESCRIPTION
this is the modern setup for semantic.works stacks and allows for more flexibility. in this case we made the move to properly set up cors on the stack