### PR TITLE
chore: bump mu-identifier

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     restart: always
     logging: *default-logging
   identifier:
-    image: semtech/mu-identifier:1.8.1
+    image: semtech/mu-identifier:1.10.1
     restart: always
     logging: *default-logging
     environment:


### PR DESCRIPTION
Bumps runtime and more aggressive header clearing for requests.  This brings it in line with other applications but there is no urgency to this PR.