### PR TITLE
GN-4573: sunset this repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # DEPRECATED: app-gn-embeddable
 
-:warning: This repository is no longer maintained and is thus unsupported. 
-Please look into the documentation of [@lblod/embeddable-say-editor](https://github.com/lblod/frontend-embeddable-notule-editor) instead to get more information on how to setup the say-editor in your project.
+> [!WARNING]  
+> This repository is no longer maintained and is thus unsupported. 
+> Please look into the documentation of [@lblod/embeddable-say-editor](https://github.com/lblod/frontend-embeddable-notule-editor) instead to get more information on how to setup the say-editor in your project.
 
 
 Backend systems and editor built on top of the Besluit and Mandaat model and application profile as defined on:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
-# app-gn-embeddable
+# DEPRECATED: app-gn-embeddable
+
+:warning: This repository is no longer maintained and is thus unsupported. 
+Please look into the documentation of [@lblod/embeddable-say-editor](https://github.com/lblod/frontend-embeddable-notule-editor) instead to get more information on how to setup the say-editor in your project.
+
+
 Backend systems and editor built on top of the Besluit and Mandaat model and application profile as defined on:
 
     http://data.vlaanderen.be/ns/besluit


### PR DESCRIPTION
### Overview
Since we moved to an npm package approach for the embeddable say-editor (https://github.com/lblod/frontend-embeddable-notule-editor), a seperate backend is no longer required. This repository is no longer maintained and thus unsupported.

##### connected issues and PRs:
[GN-4573](https://binnenland.atlassian.net/browse/GN-4573?atlOrigin=eyJpIjoiYWU1MWEyNTM5OWUzNGJjMDk5ZGExZmMwMmQ0OTRhYjYiLCJwIjoiaiJ9)

### How to test/reproduce
N/A

### Challenges/uncertainties
N/A
